### PR TITLE
executable ruby packer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Executable
+a.exe
+
+rubyc
+
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'capistrano-rails', group: :development
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.1.0', require: false
+#gem 'bootsnap', '>= 1.1.0', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,6 @@ GEM
       actionpack (>= 3.2)
       railties (>= 3.2)
     bindex (0.8.1)
-    bootsnap (1.4.4)
-      msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
     capybara (3.26.0)
@@ -133,7 +131,6 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    msgpack (1.3.0)
     nio4r (2.4.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -226,7 +223,6 @@ PLATFORMS
 
 DEPENDENCIES
   best_in_place
-  bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
   chromedriver-helper
@@ -256,4 +252,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+#require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
Read the documentation sent separately to download and execute rubyc to create an executable. Rubyc cannot package with bootsnap gem, as it only allows gemfiles using ruby's IO. Thus commenting it fixes the issue